### PR TITLE
Fix bug where clicking first track does not play

### DIFF
--- a/app.js
+++ b/app.js
@@ -455,7 +455,7 @@ function createPlaylistSub(sub) {
 function reset(state) {
     state.time = 0
     state.duration = 0
-    state.trackIndex = null
+    state.trackIndex = -1
     state.tracks = []
     state.removed = []
     state.archives = []

--- a/app.js
+++ b/app.js
@@ -455,7 +455,7 @@ function createPlaylistSub(sub) {
 function reset(state) {
     state.time = 0
     state.duration = 0
-    state.trackIndex = 0
+    state.trackIndex = null
     state.tracks = []
     state.removed = []
     state.archives = []


### PR DESCRIPTION
Previously, upon initial page load, if you click the first track in a
playlist, the UI would indicate that the song is playing but no music
would play.

This was because state.trackIndex is initialized to 0, so when we go
into play(), datradio would assume that the first track was already
playing, and then call resumeTrack instead of playTrack.

Now, we initialize state.trackIndex to null, such that clicking the
first track will correctly begin playing rather than attempting to
resume.